### PR TITLE
[feature/help-modal] 홈 진입전 발생시 도움 받기 에서 앱 정보 확인 가능

### DIFF
--- a/src/components/helpModal.js
+++ b/src/components/helpModal.js
@@ -75,7 +75,11 @@ export class HelpModal extends Component{
         },
         {title: '앱 정보', data: [
           {label: '앱 정보', icon: 'information', onPress: ()=>{
-            NavigationService.navigate('About');
+            let restoreModal = ()=>{
+              this.setVisible(true);
+            };
+            this.setVisible(false);
+            NavigationService.navigate('About', {onBack: restoreModal});
           }},
         ]
         }

--- a/src/components/helpModal.js
+++ b/src/components/helpModal.js
@@ -71,6 +71,12 @@ export class HelpModal extends Component{
             await WebBrowser.openBrowserAsync('http://sid.skhu.ac.kr/SID02/SID0201');
           }}
         ]
+        },
+        {title: '앱 정보', data: [
+          {label: '앱 정보', icon: 'information', onPress: ()=>{
+            this.props.navigation.navigate('About');
+          }},
+        ]
         }
       ];
     }

--- a/src/components/helpModal.js
+++ b/src/components/helpModal.js
@@ -4,6 +4,7 @@ import {MaterialCommunityIcons} from '@expo/vector-icons';
 import ListItem from './listitem';
 import {InfoModal} from './infoModal';
 import * as WebBrowser from 'expo-web-browser';
+import NavigationService from '../tools/NavigationService';
 
 export class HelpModal extends Component{
   setVisible(visible) {
@@ -74,7 +75,7 @@ export class HelpModal extends Component{
         },
         {title: '앱 정보', data: [
           {label: '앱 정보', icon: 'information', onPress: ()=>{
-            this.props.navigation.navigate('About');
+            NavigationService.navigate('About');
           }},
         ]
         }

--- a/src/screens/about.js
+++ b/src/screens/about.js
@@ -35,6 +35,14 @@ export default class About extends Component{
       });
     }
 
+    // 해당 컴포넌트가 화면에서 사라질 때 작동할 것들
+    componentWillUnmount() {
+      const onBack = this.props.navigation.getParam('onBack');
+      if (onBack) {
+        onBack();
+      }
+    }
+
     render(){
       let modal = this.state.modal;
       return(


### PR DESCRIPTION
로그인 도중 발생한 오류에 대해 문의하거나 오류 보고 시 앱 버전 등 확인이 가능하도록 수정.
로그인 완료 전에 도움받기 모달을 연 경우에 한하여 계정 복구 메뉴 아래에 앱 정보 항목도 표시