### PR TITLE
[hofix/dark-mode-config] 다크모드 설정 오류 수정

### DIFF
--- a/app.json
+++ b/app.json
@@ -27,12 +27,12 @@
         }
       ]
     },
+    "userInterfaceStyle": "automatic",
     "ios": {
       "bundleIdentifier": "com.sowl.skhus",
       "buildNumber": "0.5.0",
       "icon": "./assets/imgs/ios.png",
       "supportsTablet": true,
-      "userInterfaceStyle": "automatic",
       "infoPlist": {
         "NSFaceIDUsageDescription": "민감한 개인정보나 본인 인증 관련 기능 사용 전 인증을 하기 위해 사용됩니다.\n To authenticate before accessing personal data or personal authentication relates features",
         "NSLocationWhenInUseUsageDescription": "현재 위치 정보를 얻어 해당 위치의 날씨 정보를 표시하기 위해 사용됩나다.\n To provide weather informations for your current location.",

--- a/src/legal.js
+++ b/src/legal.js
@@ -81,7 +81,10 @@ const LegalInfo = {
   ],
   oss: [
     {
-      name: 'Expo SDK',
+      name: 'Expo SDK \
+      (expo, expo-asset, expo-constants, expo-linear-gradient, \
+        expo-local-authentication, expo-print, expo-secure-store, \
+        expo-sqlite, expo-web-browser',
       author: 'Expo',
       url: 'https://github.com/expo/expo-sdk',
       license: 'BSD 3-clause license',
@@ -135,6 +138,55 @@ const LegalInfo = {
       url: 'https://github.com/immutable-js/immutable-js',
       license: 'MIT License',
       licenseUrl: 'https://github.com/immutable-js/immutable-js/blob/master/LICENSE'
+    },
+    {
+      name: 'Sentry Expo',
+      author: 'Expo',
+      url: 'https://github.com/expo/sentry-expo',
+      license: 'MIT License',
+      licenseUrl: 'https://github.com/expo/sentry-expo'
+    },
+    {
+      name: '@react-native-community/netinfo',
+      author: 'React Native Community',
+      url: 'https://github.com/react-native-community/react-native-netinfo',
+      license: 'MIT License',
+      licenseUrl: 'https://github.com/react-native-community/react-native-netinfo/blob/master/LICENSE'
+    },
+    {
+      name: 'AbortController polyfill for abortable fetch()',
+      author: 'molsson',
+      url: 'https://github.com/mo/abortcontroller-polyfill',
+      license: 'MIT License',
+      licenseUrl: 'https://github.com/mo/abortcontroller-polyfill/blob/master/LICENSE'
+    },
+    {
+      name: 'react-native-dotenv',
+      author: 'David Chang',
+      url: 'https://github.com/zetachang/react-native-dotenv',
+      license: 'MIT License',
+      licenseUrl: 'https://github.com/zetachang/react-native-dotenv/blob/master/LICENSE'
+    },
+    {
+      name: 'react-native-appearance',
+      author: 'Expo',
+      url: 'https://github.com/expo/react-native-appearance',
+      license: 'MIT License',
+      licenseUrl: 'https://github.com/expo/react-native-appearance/blob/master/LICENSE'
+    },
+    {
+      name: 'react-native-gesture-handler',
+      author: 'Software Mansion',
+      url: 'https://github.com/software-mansion/react-native-gesture-handler',
+      license: 'MIT License',
+      licenseUrl: 'https://github.com/software-mansion/react-native-gesture-handler/blob/master/LICENSE'
+    },
+    {
+      name: 'React Native Reanimated',
+      author: 'Software Mansion',
+      url: 'https://github.com/software-mansion/react-native-reanimated',
+      license: 'MIT License',
+      licenseUrl: 'https://github.com/software-mansion/react-native-reanimated/blob/master/LICENSE'
     }
   ]};
 


### PR DESCRIPTION
ios 에 대해서만 다크모드 설정값이 들어가 있어, Android 에서 다크모드가 작동을 안함. 해당 값을 전역 설정으로 이동하여 두 플랫폼 모두 작동하도록 수정.

앱 빌드 및 스토어 업데이트 필요.