### PR TITLE
[hotfix/schedules-line] 스케줄의 날짜와 내용이 밀리는 현상

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -17,6 +17,7 @@ import DBHelper from './tools/dbhelper';
 import {MaterialIcons} from '@expo/vector-icons';
 import Touchable from './components/touchable';
 import LocalAuth from './components/localauth';
+import ScheduleTable from './components/scheduletable';
 import {MealCard} from './screens/meal';
 import {useTheme} from '@react-navigation/native';
 import {WhatsNewModal, shouldShowWhatsNew} from './components/whatsNewModal';
@@ -264,65 +265,20 @@ class NextClassInfo extends Component {
 class MonthlySchedule extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      dates: '',
-      contents: '',
-      isLoading: false,
-    };
   }
   async componentDidMount() {
-    this.setState({isLoading: true});
-    let today = new Date();
-    let schedule = await ForestApi.post(
-      '/life/schedules',
-      JSON.stringify({
-        year: today.getFullYear(),
-        month: today.getMonth() + 1,
-      }),
-      false
-    );
-    if (schedule.ok) {
-      let data = await schedule.json();
-      let dates = '',
-        contents = '';
-      for (let item of data.schedules) {
-        dates += `${item.period}\n`;
-        contents += ` | ${item.content}\n`;
-      }
-      this.setState({
-        dates: dates,
-        contents: contents,
-        isLoading: false,
-      });
-    }
   }
   render() {
-    let content;
-    if (this.state.isLoading) {
-      content = (
-        <View style={{justifyContent: 'center', padding: 32}}>
-          <ActivityIndicator size="large" color={BuildConfigs.primaryColor} />
-        </View>
-      );
-    } else {
-      content = (
-        <View>
-          <View style={{flexDirection: 'row'}}>
-            <ThemedText style={{flex: 0, fontWeight: 'bold'}}>
-              {this.state.dates}
-            </ThemedText>
-            <ThemedText style={{flex: 1}}>{this.state.contents}</ThemedText>
-          </View>
-        </View>
-      );
-    }
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = today.getMonth() + 1;
     return (
       <CardView
         onPress={this.props.onPress}
         elevate={true}
         actionLabel="학사 일정 더 보기 >"
       >
-        {content}
+        <ScheduleTable year={year} month={month} />
       </CardView>
     );
   }

--- a/src/components/scheduletable.js
+++ b/src/components/scheduletable.js
@@ -1,0 +1,68 @@
+import React, {Component} from 'react';
+import {View, ActivityIndicator} from 'react-native';
+import {ThemedText} from '../components/components';
+import BuildConfigs from '../config';
+import ForestApi from '../tools/apis';
+
+export default class ScheduleTable extends Component{
+  constructor(props){
+    super(props);
+    this.state = {
+      dates: [],
+      contents: [],
+      isLoading: false
+    };
+  }
+  async componentDidMount(){
+    this.setState({isLoading: true});
+    let schedule = await ForestApi.post('/life/schedules', JSON.stringify({
+      'year': this.props.year,
+      'month': this.props.month
+    }), false);
+    if(schedule.ok){
+      let data = await schedule.json();
+      let dates = [], contents = [];
+      for(let item of data.schedules){
+        dates.push(`${item.period}`);
+        contents.push(` | ${item.content}`);
+      }
+      this.setState({
+        dates: dates,
+        contents: contents,
+        isLoading: false
+      });
+    }
+  }
+  render(){
+    let content;
+    if(this.state.isLoading){
+      content = (
+        <View style={{justifyContent: 'center'}}>
+          <ActivityIndicator size="large" color={BuildConfigs.primaryColor} />
+        </View>
+      );
+    }else{
+      scheduleTable = [];
+      for (const i in this.state.dates) {
+        const con = this.state.contents[i];
+        const date = this.state.dates[i];
+        scheduleTable.push(
+          <View style={{width: '100%', flexDirection: 'row'}} key={con + date}>
+            <ThemedText style={{flex:0, width: '35%',fontWeight: 'bold'}}>{date}</ThemedText>
+            <ThemedText style={{flex:1, flexWrap: 'wrap'}}>{con}</ThemedText>
+          </View>
+        );
+      }
+      content = (
+        <View style={{alignItems: 'center'}}>
+          { scheduleTable }
+        </View>
+      );
+    }
+    return(
+      <View>
+        {content}
+      </View>
+    );
+  }
+}

--- a/src/components/scheduletable.js
+++ b/src/components/scheduletable.js
@@ -24,7 +24,7 @@ export default class ScheduleTable extends Component{
       let dates = [], contents = [];
       for(let item of data.schedules){
         dates.push(`${item.period}`);
-        contents.push(` | ${item.content}`);
+        contents.push(` ${item.content}`);
       }
       this.setState({
         dates: dates,

--- a/src/screens/schedules.js
+++ b/src/screens/schedules.js
@@ -1,81 +1,38 @@
 import React, {Component} from 'react';
 import ListItem from '../components/listitem';
-import {ScrollView, View, Text, ActivityIndicator} from 'react-native';
-import ForestApi from '../tools/apis';
-import BuildConfigs from '../config';
-import moment from 'moment';
 import {ThemedText} from '../components/components';
-
+import ScheduleTable from '../components/scheduletable';
+import {ScrollView, View} from 'react-native';
+import moment from 'moment';
 
 export default class Schedules extends Component{
   constructor(props){
     super(props);
   }
   render(){
+    let tables = [];
+    let months = moment();
+
+    for (let i = 0; i < 3; i++) {
+      let year = moment().year();
+      tables.push(
+        <View>
+          <ListItem isHeader={true}>
+            <ThemedText>{year}{'.'}{months.month() + 1}</ThemedText>
+          </ListItem>
+          <ListItem>
+            <ScheduleTable year={year} month={months.month()+1}/>
+          </ListItem>
+        </View>
+      );
+
+      months.add(1, 'months');
+    }
+
     return(
       <ScrollView style={{height: '100%'}}>
-        <ScheduleComponent year={moment().year()} month={moment().month()+1}/>
-        <ScheduleComponent year={moment().add(1, 'months').year()} month={moment().add(1, 'months').month()+1}/>
-        <ScheduleComponent year={moment().add(2, 'months').year()} month={moment().add(2, 'months').month()+1}/>
+        { tables }
       </ScrollView>
-    );
-  }
-}
-
-class ScheduleComponent extends Component{
-  constructor(props){
-    super(props);
-    this.state = {
-      dates: '',
-      contents: '',
-      isLoading: false
-    };
-  }
-  async componentDidMount(){
-    this.setState({isLoading: true});
-    let schedule = await ForestApi.post('/life/schedules', JSON.stringify({
-      'year': this.props.year,
-      'month': this.props.month
-    }), false);
-    if(schedule.ok){
-      let data = await schedule.json();
-      let dates = '', contents = '';
-      for(let item of data.schedules){
-        dates += `${item.period}\n`;
-        contents += ` | ${item.content}\n`;
-      }
-      this.setState({
-        dates: dates,
-        contents: contents,
-        isLoading: false
-      });
-    }
-  }
-  render(){
-    let content;
-    if(this.state.isLoading){
-      content = (
-        <View style={{justifyContent: 'center'}}>
-          <ActivityIndicator size="large" color={BuildConfigs.primaryColor} />
-        </View>
-      );
-    }else{
-      content = (
-        <View style={{flexDirection: 'row'}}>
-          <ThemedText style={{flex: 0, fontWeight: 'bold'}}>{this.state.dates}</ThemedText>
-          <ThemedText style={{flex: 1}}>{this.state.contents}</ThemedText>
-        </View>
-      );
-    }
-    return(
-      <View>
-        <ListItem isHeader={true}>
-          <ThemedText>{this.props.year}{'.'}{this.props.month}</ThemedText>
-        </ListItem>
-        <ListItem>
-          {content}
-        </ListItem>
-      </View>
     );
   }
 }


### PR DESCRIPTION
구조는 기본적으로 테이블이 맞다. 하지만 칸 두개로 각각 날짜와 내용을 한
문자열에 추가해서 저장하니 디바이스 크기에 따른 문제, 일정 내용이 긴
문제로 해당 문제가 발생하는 것 같다.

해결방법은 각 일정 마다 행과 열을 만들어주면 화면에 맞게 그려준다.
그리고 컴포넌트로 분리해서 메인화면에서도 똑같은 결과를 전달할 수 있게
변경한다.